### PR TITLE
Support update for individual Lambda functions

### DIFF
--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -92,7 +92,10 @@ class GroupCommands(object):
         # 5. Create devices (coming soon)
 
         # 6. Create subscriptions
-        self.create_subscriptions()
+        self.create_subscriptions(update_group_version=False)
+
+        # 7. Create logger definitions
+        self.create_loggers()  # TODO: I'll also need group-version update to change it later...
 
         # LAST. Add all the constituent parts to the Greengrass Group
         self.create_group_version()
@@ -150,7 +153,7 @@ class GroupCommands(object):
             DeviceDefinitionVersionArn="",
             FunctionDefinitionVersionArn=state['FunctionDefinition']['LatestVersionArn'],
             SubscriptionDefinitionVersionArn=state['Subscriptions']['LatestVersionArn'],
-            LoggerDefinitionVersionArn="",
+            LoggerDefinitionVersionArn=state['Loggers']['LatestVersionArn'],
             ResourceDefinitionVersionArn=state['Resources']['LatestVersionArn'],
         )
 
@@ -327,7 +330,7 @@ class GroupCommands(object):
 
         log.info("Lambdas and function definition deleted OK!")
 
-    def create_subscriptions(self):
+    def create_subscriptions(self, update_group_version=True):
         if not self.group.get('Subscriptions'):
             log.info("Subscriptions not defined. Moving on...")
             return
@@ -365,6 +368,10 @@ class GroupCommands(object):
 
         self.state['Subscriptions']['LatestVersionDetails'] = rinse(sub_def_ver)
         _update_state(self.state)
+
+        if update_group_version:
+            log.info("Updating group version with new Lambdas...")
+            self.create_group_version()
 
         log.info("Subscription definition created OK!")
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -82,7 +82,7 @@ class GroupCommandTest(unittest.TestCase):
         self.gg.create_group_version()
 
         args, kwargs = m.call_args
-        self.assertEqual(len(kwargs), 5)  # TODO: Refine expected kwarg count
+        self.assertEqual(len(kwargs), 6)  # TODO: Refine expected kwarg count
 
     def test_create_group_version_subset(self):
         self.gg.state = greengo.State(state.copy())
@@ -94,7 +94,7 @@ class GroupCommandTest(unittest.TestCase):
         self.gg.create_group_version()
 
         args, kwargs = m.call_args
-        self.assertEqual(len(kwargs), 3)  # TODO: Refine expected kwarg count
+        self.assertEqual(len(kwargs), 4)  # TODO: Refine expected kwarg count
 
     def test_create_resources(self):
         self.gg.group.pop('Resources')


### PR DESCRIPTION
When actively developing, changing code and deploying, especially if there are MULTIPLE lambda functions in a group (common!), it's irritating to remove and create Lambda. 

Now, you can:

```
greengo update-lambda MyLambda
greengo deploy
```

Caveats: if function _definition_ changed, you better off removing and re-creating lambdas for now.

PS. Couple of bug fixes with that, too.