### PR TITLE
Download greengrasss binaries instead of keeping them in repo.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,15 +6,19 @@ sudo groupadd --system ggc_group
 sudo apt-get update
 sudo apt-get install -y sqlite3 python2.7 binutils curl
 
-wget -O /vagrant/downloads/root.ca.pem http://www.symantec.com/content/en/us/enterprise/verisign/roots/VeriSign-Class%203-Public-Primary-Certification-Authority-G5.pem
+# Download Greengrass binaries
+wget -P /vagrant/downloads https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.7.0/greengrass-linux-x86-64-1.7.0.tar.gz
 
 # Copy greengrass binaries
 sudo tar -xzf /vagrant/downloads/greengrass-linux-x86-64-1.7.0.tar.gz -C /
 
+# Download root certificate
+wget -O /vagrant/certs/root.ca.pem http://www.symantec.com/content/en/us/enterprise/verisign/roots/VeriSign-Class%203-Public-Primary-Certification-Authority-G5.pem
+
 # Copy certificates and configurations
 sudo cp /vagrant/certs/* /greengrass/certs
 sudo cp /vagrant/config/* /greengrass/config
-sudo cp /vagrant/downloads/root.ca.pem /greengrass/certs
+sudo cp /vagrant/certs/root.ca.pem /greengrass/certs
 
 # Back up group.json - you'll thank me later
 sudo cp /greengrass/ggc/deployment/group/group.json /greengrass/ggc/deployment/group/group.json.orig


### PR DESCRIPTION
Now that AWS finally posted the downloadable link, 
per [AWS Greengrass’ New Features, Announced & Hidden — from re:Invent 2018](https://medium.com/@dzimine/aws-greengrass-new-features-announced-hidden-from-re-invent-2018-a34895d3536c), I can just download it on demand.
