### PR TITLE
Add Subscriptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
   - "2.7"
-cache: pip
+# cache: pip
+
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/greengo/entity.py
+++ b/greengo/entity.py
@@ -24,27 +24,40 @@ class Entity(object):
         # Note that it's list of Types (classes), not instances.
         self._requirements = []
 
-    def _pre_create(self, update_group_version=True):
+    def _pre_create(self):
         log.info("Creating {}...".format(self.type.lower()))
-        # check if requred objects alrady created, if not, warn and exit.
-        # do the work of your own creation
-        # update requirements
-        for r in self._requirements:
-            r.add_dependant(self)
-        # add yourself to State
-        # Write to file
-        pass
 
-    def _do_create(self, update_group_version):
+        if not self._group.get(self.type):
+            log.warning("{} not defined, skipping.".format(self.type))
+            return False
+
+        if self._state.get(self.type):
+            log.warning("{} already created. Remove before creating again.".format(self.type))
+            return False
+
+        # Check if requred objects alrady created, if not - warn and exit.
+        missed = [r for r in self._requirements if r not in self._state.entities()]
+        if missed:
+            log.warning("{} must be created before {}. Please create first.".format(
+                ', '.join(missed), self.type))
+            return False
+
+        return True
+
+    def _do_create(self):
         raise NotImplementedError
 
-    def _post_create(self):
+    def _post_create(self, update_group_version):
+        if update_group_version:
+            log.info("Updating group version with new {}...".format(self.type))
+            self.create_group_version(self._state)
+
         log.info("{} created OK!".format(self.type))
 
     def create(self, update_group_version=True):
-        self._pre_create()
-        self._do_create(update_group_version)
-        self._post_create()
+        if self._pre_create():
+            self._do_create()
+            self._post_create(update_group_version)
 
     def _pre_remove(self):
         log.info("Removing {}".format(self.type.lower()))
@@ -53,6 +66,7 @@ class Entity(object):
         raise NotImplementedError
 
     def _post_remove(self):
+        self._state.remove(self.type)
         log.info("{} removed OK!".format(self.type.lower()))
 
     def remove(self):
@@ -89,5 +103,4 @@ class Entity(object):
         _gg = Entity._session.client("greengrass")
         group_ver = _gg.create_group_version(**args)
 
-        # TODO:XXX refactor state and save nested keys.
         state.update('Group.Version', group_ver)

--- a/greengo/entity.py
+++ b/greengo/entity.py
@@ -62,6 +62,12 @@ class Entity(object):
     def _pre_remove(self):
         log.info("Removing {}".format(self.type.lower()))
 
+        if not self._state.get(self.type):
+            log.warning("{} does not exist, skipping remove.".format(self.type))
+            return False
+
+        return True
+
     def _do_remove(self):
         raise NotImplementedError
 
@@ -70,9 +76,9 @@ class Entity(object):
         log.info("{} removed OK!".format(self.type.lower()))
 
     def remove(self):
-        self._pre_remove()
-        self._do_remove()
-        self._post_remove
+        if self._pre_remove():
+            self._do_remove()
+            self._post_remove()
 
     def add_dependant(self, entity):
         self._dependants.add(entity)

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -96,8 +96,14 @@ class Commands(object):
 
         log.info("[END] removing group {0}".format(self.group['Group']['name']))
 
+    def create_group(self):
+        pass
+
+    def remove_group(self):
+        pass
+
     def create_subscriptions(self, update_group_version=True):
-        log.info("Subscription definition created OK!")
+        Subscriptions(self.group, self.state).create(update_group_version=True)
 
     def remove_subscriptions(self):
         log.info("Subscription definition removed OK!")

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -106,7 +106,7 @@ class Commands(object):
         Subscriptions(self.group, self.state).create(update_group_version=True)
 
     def remove_subscriptions(self):
-        log.info("Subscription definition removed OK!")
+        Subscriptions(self.group, self.state).remove()
 
 
 def main():

--- a/greengo/group.py
+++ b/greengo/group.py
@@ -26,7 +26,7 @@ class Group(Entity):
         # self._iam = s.client("iam")
         self._iot_endpoint = self._iot.describe_endpoint()['endpointAddress']
 
-    def _do_create(self, update_group_version):
+    def _do_create(self):
         log.info("Creating group '{}'".format(self._group['Group']['name']))
 
         g = rinse(self._gg.create_group(Name=self.name))
@@ -44,8 +44,6 @@ class Group(Entity):
 
         log.info("Deleting group '{0}'".format(self._state.get('Group.Id')))
         self._gg.delete_group(GroupId=self._state.get('Group.Id'))
-
-        self._state.remove(self.type)
 
     def _create_cores(self):
         # Design notes:

--- a/greengo/state.py
+++ b/greengo/state.py
@@ -59,6 +59,10 @@ class State(object):
         tree[prev] = body
         self.save()
 
+    def entities(self):
+        ''' Get list of entities - top level keys '''
+        return self._state.keys()
+
     def get(self, key=None, default=None):
         '''
         Get value. Key may be nested using dot as separator, like 'foo.bar.buz'.

--- a/greengo/subscriptions.py
+++ b/greengo/subscriptions.py
@@ -45,7 +45,10 @@ class Subscriptions(Entity):
         self._state.update('Subscriptions.LatestVersionDetails', sub_def_ver)
 
     def _do_remove(self):
-        pass
+        log.debug("Deleting subscription definition '{0}' Id='{1}".format(
+            self.name, self._state.get('Subscriptions.Id')))
+        self._gg.delete_subscription_definition(
+            SubscriptionDefinitionId=self._state.get('Subscriptions.Id'))
 
     def _resolve_subscription_destination(self, d):
         p = [x.strip() for x in d.split('::')]

--- a/greengo/subscriptions.py
+++ b/greengo/subscriptions.py
@@ -1,6 +1,8 @@
 from entity import Entity
 import logging
 
+from utils import pretty, rinse
+
 log = logging.getLogger(__name__)
 
 
@@ -9,10 +11,72 @@ class Subscriptions(Entity):
     def __init__(self, group, state):
         super(Subscriptions, self).__init__(group, state)
         self.type = 'Subscriptions'
+        self.name = group['Group']['name'] + '_subscriptions'
 
-    def _do_create(self, update_group_version=True):
-        log.info("Creating subscription '{}'".format(self._group['Subscriptions']))
-        self._state.update(self.type, {})
+        self._requirements = ['Group']
+        self._gg = Entity._session.client("greengrass")
+
+    def _do_create(self):
+        log.debug("Preparing subscription list...")
+        subs = []
+        for i, s in enumerate(self._group['Subscriptions']):
+            log.debug("Subscription '{0}' - '{1}': {2}->{3}'".format(
+                i, s['Subject'], s['Source'], s['Target']))
+            subs.append({
+                'Id': str(i),
+                'Source': self._resolve_subscription_destination(s['Source']),
+                'Target': self._resolve_subscription_destination(s['Target']),
+                'Subject': s['Subject']
+            })
+        log.debug("Subscription list is ready:\n{0}".format(pretty(subs)))
+
+        log.info("Creating subscription definition: '{0}'".format(self.name))
+        sub_def = rinse(self._gg.create_subscription_definition(
+            Name=self.name,
+            InitialVersion={'Subscriptions': subs}
+        ))
+
+        self._state.update('Subscriptions', sub_def)
+
+        sub_def_ver = rinse(self._gg.get_subscription_definition_version(
+            SubscriptionDefinitionId=self._state.get('Subscriptions.Id'),
+            SubscriptionDefinitionVersionId=self._state.get('Subscriptions.LatestVersion')
+        ))
+        self._state.update('Subscriptions.LatestVersionDetails', sub_def_ver)
 
     def _do_remove(self):
         pass
+
+    def _resolve_subscription_destination(self, d):
+        p = [x.strip() for x in d.split('::')]
+        if p[0] == 'cloud':
+            return p[0]
+        elif p[0] == 'Lambda':
+            return self._lookup_lambda_qualified_arn(p[1])
+        elif p[0] == 'Device':
+            return self._lookup_device_arn(p[1])
+        elif p[0] == 'GGShadowService':
+            return p[0]
+        elif p[0] == 'Connector':
+            return self._lookup_connector_arn(p[1])
+        else:
+            raise ValueError(
+                "Error parsing subscription destination '{0}'. Allowed values: "
+                "'Lambda::', 'Device::', 'Connector::', 'GGShadowService', or 'cloud'.".format(d))
+
+    def _lookup_lambda_qualified_arn(self, name):
+        for l in self._state.get('FunctionDefinition.LatestVersionDetails.Definition.Functions', []):
+            if l['Id'] == name:
+                return l['FunctionArn']
+        log.error("Lambda '{0}' not found".format(name))
+        return None
+
+    def _lookup_device_arn(self, name):
+        raise NotImplementedError("WIP: Devices not implemented yet.")
+
+    def _lookup_connector_arn(self, name):
+        for l in self._state('Connectors.LatestVersionDetails.Definition.Connectors'):
+            if l['Id'] == name:
+                return l['ConnectorArn']
+        log.error("Connector '{0}' not found".format(name))
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ botocore
 pyyaml
 # Testing requirements
 mock
-pytest
+pytest>=4.0.1
 unittest2
 pytest-flakes
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pyyaml
 # Testing requirements
 mock
 pytest
+unittest2
 pytest-flakes
 pytest-cov

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,52 @@
+from mock import MagicMock
+from greengo.state import State
+
+state = State("tests/test_state.json")
+
+
+def clone_test_state():
+    global state
+    s = State(file=None)
+    s._state = state._state.copy()
+    return s
+
+
+class BotoSessionFixture():
+    region_name = 'moon-darkside'
+
+    def __init__(self):
+        global state
+
+        self.greengrass = MagicMock()
+        self.greengrass.create_group = MagicMock(
+            return_value=state.get('Group'))
+        self.greengrass.create_core_definition = MagicMock(
+            return_value=state.get('CoreDefinition'))
+
+        subscriptions_return = state.get('Subscriptions').copy()
+        subscription_definition_return = subscriptions_return.pop('LatestVersionDetails')
+
+        self.greengrass.create_subscription_definition = MagicMock(
+            return_value=subscriptions_return)
+        self.greengrass.get_subscription_definition_version = MagicMock(
+            return_value=subscription_definition_return)
+
+        self.iot = MagicMock()
+        self.iot.create_keys_and_certificate = MagicMock(
+            return_value=state.get('Cores')[0]['keys'])
+        self.iot.create_thing = MagicMock(
+            return_value=state.get('Cores')[0]['thing'])
+        self.iot.describe_endpoint = MagicMock(
+            return_value={
+                'endpointAddress': "foobar.iot.{}.amazonaws.com".format(self.region_name)
+            })
+        self.iot.create_policy = MagicMock(
+            return_value=state.get('Cores')[0]['policy'])
+
+    def client(self, name):
+        if name == 'greengrass':
+            return self.greengrass
+        elif name == 'iot':
+            return self.iot
+
+        return MagicMock()

--- a/tests/test_state.json
+++ b/tests/test_state.json
@@ -242,6 +242,6 @@
       "Id": "37d25372-c98e-4435-978d-756b14a11911",
       "Version": "2e73b2cc-d8d0-4713-9f72-08240429b55b"
     },
-    "Name": "GreengoGroup_subscription"
+    "Name": "GreengoGroup_subscriptions"
   }
 }


### PR DESCRIPTION
Now that we can create group and core, time to learn how to add other entities. 
I do Subscriptions as one of the simplest. Once this done, the main design should be solid to add many more. 

- [x] create entity - not defined 
- [x] create entity - already created
- [x] create entity - misses dependencies
- [x] create subscription - for real
- [x] remove subscription
- [x] ~~test with CLI~~ can't test well without Lambdas
