### PR TITLE
Add support for Lambdas

### DIFF
--- a/greengo.yaml
+++ b/greengo.yaml
@@ -9,6 +9,7 @@ Cores:
 
 Lambdas:
   - name: GreengrassHelloWorld
+    runtime: python2.7
     handler: function.handler
     package: lambdas/GreengrassHelloWorld
     alias: dev

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -1,26 +1,18 @@
 import os
 import fire
 import yaml
-# import shutil
-# import urllib
 import logging
 from boto3 import session
-# from botocore.exceptions import ClientError
 
 from __init__ import __version__
 
-from entity import Entity
+from .entity import Entity
 from state import State
 from group import Group
 from lambdas import Lambdas
 from subscriptions import Subscriptions
 
-logging.basicConfig(
-    format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
-    level=logging.WARNING)
-
-log = logging.getLogger('greengo')
-log.setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 DEFINITION_FILE = 'greengo.yaml'
@@ -106,13 +98,17 @@ class Commands(object):
         Subscriptions(self.group, self.state).create(update_group_version=True)
 
     def remove_lambdas(self):
-        raise NotImplementedError
+        Lambdas(self.group, self.state).remove()
 
     def remove_subscriptions(self):
         Subscriptions(self.group, self.state).remove()
 
 
 def main():
+    logging.basicConfig(
+        format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
+        level=logging.WARNING)
+    logging.getLogger('greengo').setLevel(logging.DEBUG)
     fire.Fire(Commands)
 
 if __name__ == '__main__':

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -12,6 +12,7 @@ from __init__ import __version__
 from entity import Entity
 from state import State
 from group import Group
+from lambdas import Lambdas
 from subscriptions import Subscriptions
 
 logging.basicConfig(
@@ -42,13 +43,7 @@ class Commands(object):
         log.info("AWS credentials found for region '{}'".format(self._region))
 
         Entity._session = s
-
-        # XXX: remvoe this
-        self._gg = s.client("greengrass")
-        self._iot = s.client("iot")
-        self._lambda = s.client("lambda")
-        self._iam = s.client("iam")
-        self._iot_endpoint = self._iot.describe_endpoint()['endpointAddress']
+        # self._iot_endpoint = s.client("iot").describe_endpoint()['endpointAddress']
 
         try:
             with open(DEFINITION_FILE, 'r') as f:
@@ -75,6 +70,8 @@ class Commands(object):
 
         Group(self.group, self.state).create(update_group_version=False)
 
+        Lambdas(self.group, self.state).create(update_group_version=False)
+
         Subscriptions(self.group, self.state).create(update_group_version=False)
 
         # Create other entities like this...
@@ -97,13 +94,19 @@ class Commands(object):
         log.info("[END] removing group {0}".format(self.group['Group']['name']))
 
     def create_group(self):
-        pass
+        NotImplementedError
 
     def remove_group(self):
-        pass
+        NotImplementedError
+
+    def create_lambdas(self, update_group_version=True):
+        Lambdas(self.group, self.state).create(update_group_version=True)
 
     def create_subscriptions(self, update_group_version=True):
         Subscriptions(self.group, self.state).create(update_group_version=True)
+
+    def remove_lambdas(self):
+        raise NotImplementedError
 
     def remove_subscriptions(self):
         Subscriptions(self.group, self.state).remove()

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -53,6 +53,9 @@ class Commands(object):
     def version(self):
         print('Greengo version {}'.format(__version__))
 
+    def state(self):
+        print(self.state)
+
     def create(self):
         if self.state.get():
             log.error("Previously created group exists. Remove before creating!")
@@ -79,26 +82,32 @@ class Commands(object):
 
         log.info("[BEGIN] removing group {0}".format(self.group['Group']['name']))
 
-        Group(self.group, self.state).remove()
+        Subscriptions(self.group, self.state).remove(update_group_version=False)
+
+        Lambdas(self.group, self.state).remove(update_group_version=False)
+
+        # Remove other entities here, before removing Group.
+
+        Group(self.group, self.state).remove(update_group_version=False)
 
         self.state.remove()
 
         log.info("[END] removing group {0}".format(self.group['Group']['name']))
 
     def create_group(self):
-        NotImplementedError
+        Group(self.group, self.state).create()
 
     def remove_group(self):
-        NotImplementedError
+        Group(self.group, self.state).remove()
 
-    def create_lambdas(self, update_group_version=True):
-        Lambdas(self.group, self.state).create(update_group_version=True)
-
-    def create_subscriptions(self, update_group_version=True):
-        Subscriptions(self.group, self.state).create(update_group_version=True)
+    def create_lambdas(self):
+        Lambdas(self.group, self.state).create()
 
     def remove_lambdas(self):
         Lambdas(self.group, self.state).remove()
+
+    def create_subscriptions(self):
+        Subscriptions(self.group, self.state).create()
 
     def remove_subscriptions(self):
         Subscriptions(self.group, self.state).remove()

--- a/greengo/group.py
+++ b/greengo/group.py
@@ -8,9 +8,6 @@ from utils import rinse, mkdir, save_keys
 
 log = logging.getLogger(__name__)
 
-# TODO(dzimine): move to proper logger config
-log.setLevel(logging.DEBUG)
-
 
 class Group(Entity):
 

--- a/greengo/lambdas.py
+++ b/greengo/lambdas.py
@@ -1,0 +1,174 @@
+import shutil
+import os
+from time import sleep
+import json
+from botocore.exceptions import ClientError
+import logging
+
+from entity import Entity
+from utils import pretty, rinse
+
+MAGIC_DIR = '.gg'  # XXX: better way?
+
+log = logging.getLogger(__name__)
+
+
+class Lambdas(Entity):
+    def __init__(self, group, state):
+        super(Lambdas, self).__init__(group, state)
+        self.type = 'Lambdas'
+        self.name = group['Group']['name'] + '_lambdas'
+        self._LAMBDA_ROLE_NAME = "{0}_Lambda_Role".format(self.name)
+
+        self._requirements = ['Group']
+        self._gg = Entity._session.client("greengrass")
+        self._iam = Entity._session.client("iam")
+        self._lambda = Entity._session.client("lambda")
+
+    def _do_create(self):
+        functions = []
+        self._state.update('Lambdas', [])  # XXX do this better.
+        for l in self._group['Lambdas']:
+            log.info("Creating Lambda function '{0}'".format(l['name']))
+
+            # Use existing role if provided, or create & use default role.
+            role_arn = l['role'] if 'role' in l else self._default_lambda_role_arn()
+            log.info("Assuming role '{0}'".format(role_arn))
+
+            zf = shutil.make_archive(
+                os.path.join(MAGIC_DIR, l['name']), 'zip', l['package'])
+            log.debug("Lambda deployment Zipped to '{0}'".format(zf))
+
+            for retry in range(3):
+                try:
+                    with open(zf, 'rb') as f:
+                        lr = self._lambda.create_function(
+                            FunctionName=l['name'],
+                            Runtime=l['runtime'],
+                            Role=role_arn,
+                            Handler=l['handler'],
+                            Code=dict(ZipFile=f.read()),
+                            Environment=dict(Variables=l.get('environment', {})),
+                            Publish=True
+                        )
+                        # Break from retry cycle if lambda is created
+                        break
+                except ClientError as e:  # Catch the right exception
+                    if "The role defined for the function cannot be assumed by Lambda" in str(e):
+                        # Function creation immediately after role creation fails with
+                        # "The role defined for the function cannot be assumed by Lambda."
+                        # See StackOverflow https://goo.gl/eTfqsS
+                        log.warning("We hit AWS bug: the role is not yet propagated. "
+                                    "Taking 5 sec nap")
+                        sleep(5)
+                        continue
+                    else:
+                        raise(e)
+
+            lr['ZipPath'] = zf
+
+            self._state.get('Lambdas').append(rinse(lr))
+            self._state.save()  # This only needed as `append` only modified state in memory.
+            log.info("Lambda function '{0}' created".format(lr['FunctionName']))
+
+            # Auto-created alias uses the version of just published function
+            alias = self._lambda.create_alias(
+                FunctionName=lr['FunctionName'],
+                Name=l.get('alias', 'default'),
+                FunctionVersion=lr['Version'],
+                Description='Created by greengo'
+            )
+            log.info("Lambda alias created. FunctionVersion:'{0}', Arn:'{1}'".format(
+                alias['FunctionVersion'], alias['AliasArn']))
+
+            functions.append({
+                'Id': l['name'],
+                'FunctionArn': alias['AliasArn'],
+                'FunctionConfiguration': l['greengrassConfig']
+            })
+
+        log.debug("Function definition list ready:\n{0}".format(pretty(functions)))
+
+        log.info("Creating function definition: '{0}'".format(self.name + '_func_def_1'))
+        fd = self._gg.create_function_definition(
+            Name=self.name + '_func_def_1',
+            InitialVersion={'Functions': functions}
+        )
+        self._state.update('FunctionDefinition', rinse(fd))
+
+        fd_ver = self._gg.get_function_definition_version(
+            FunctionDefinitionId=self._state.get('FunctionDefinition.Id'),
+            FunctionDefinitionVersionId=self._state.get('FunctionDefinition.LatestVersion'))
+
+        self._state.update('FunctionDefinition.LatestVersionDetails', rinse(fd_ver))
+
+    def _default_lambda_role_arn(self):
+        if self._state.get('LambdaRole'):
+            log.info("Default lambda role '{0}' already creted, RoleId={1} ".format(
+                self._LAMBDA_ROLE_NAME, self._state.get('LambdaRole.Role.RoleId')))
+        else:
+            try:
+                role = self._create_default_lambda_role()
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'EntityAlreadyExists':
+                    role = self._iam.get_role(RoleName=self._LAMBDA_ROLE_NAME)
+                    log.warning("Role {0} already exists, reusing.".format(self._LAMBDA_ROLE_NAME))
+                else:
+                    raise e
+
+            self._state.update('LambdaRole', rinse(role))
+        return self._state.get('LambdaRole.Role.Arn')
+
+    def _create_default_lambda_role(self):
+        # TODO: redo as template and read from definition .yaml
+        log.info("Creating default lambda role '{0}'".format(self._LAMBDA_ROLE_NAME))
+        role_policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+
+                }
+            ]
+        }
+
+        role = self._iam.create_role(
+            RoleName=self._LAMBDA_ROLE_NAME,
+            AssumeRolePolicyDocument=json.dumps(role_policy_document)
+        )
+
+        log.info("Creating lambda role policy '{0}'".format(
+            self._LAMBDA_ROLE_NAME + "_Policy"))
+        inline_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                    ],
+                    "Resource": "arn:aws:logs:*:*:*"
+                }
+            ]
+        }
+
+        self._iam.put_role_policy(
+            RoleName=self._LAMBDA_ROLE_NAME,
+            PolicyName=self._LAMBDA_ROLE_NAME + "_Policy",
+            PolicyDocument=json.dumps(inline_policy))
+
+        return role
+
+    def _remove_default_lambda_role(self):
+        for p in self._iam.list_role_policies(RoleName=self._LAMBDA_ROLE_NAME)['PolicyNames']:
+            log.info("Deleting lambda role policy '{0}'".format(p))
+            self._iam.delete_role_policy(RoleName=self._LAMBDA_ROLE_NAME, PolicyName=p)
+
+        log.info("Deleting default lambda role '{0}'".format(self._LAMBDA_ROLE_NAME))
+        self._iam.delete_role(RoleName=self._LAMBDA_ROLE_NAME)

--- a/greengo/lambdas.py
+++ b/greengo/lambdas.py
@@ -120,7 +120,10 @@ class Lambdas(Entity):
         for l in self._state.get('Lambdas'):
             log.info("Deleting Lambda function '{0}'".format(l['FunctionName']))
             self._lambda.delete_function(FunctionName=l['FunctionName'])
-            os.remove(l['ZipPath'])
+            try:
+                os.remove(l['ZipPath'])
+            except OSError as e:
+                log.warning("Failed to remove local Lambda zip package: {}".format(e))
 
         self._state.remove('Lambdas')
 

--- a/greengo/state.py
+++ b/greengo/state.py
@@ -41,6 +41,11 @@ class State(object):
             utils.mkdir(os.path.dirname(self._file))
             self.save()
 
+    def __str__(self):
+        if not self._state:
+            return "State not created."
+        return utils.pretty(self._state)
+
     def exists(self):
         return bool(self._state)
 

--- a/greengo/subscriptions.py
+++ b/greengo/subscriptions.py
@@ -78,7 +78,7 @@ class Subscriptions(Entity):
         raise NotImplementedError("WIP: Devices not implemented yet.")
 
     def _lookup_connector_arn(self, name):
-        for l in self._state('Connectors.LatestVersionDetails.Definition.Connectors'):
+        for l in self._state.get('Connectors.LatestVersionDetails.Definition.Connectors'):
             if l['Id'] == name:
                 return l['ConnectorArn']
         log.error("Connector '{0}' not found".format(name))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,6 +15,7 @@ class BotoSessionFixture():
     region_name = 'moon-darkside'
 
     def __init__(self):
+        # MAYBE: move to a method and get state clone with clone_test_state every time?
         global state
 
         self.greengrass = MagicMock()
@@ -31,6 +32,15 @@ class BotoSessionFixture():
         self.greengrass.get_subscription_definition_version = MagicMock(
             return_value=subscription_definition_return)
 
+        function_definition_return = state.get('FunctionDefinition').copy()
+        function_definition_version_return = function_definition_return.pop('LatestVersionDetails')
+
+        self.greengrass.create_function_definition = MagicMock(
+            return_value=function_definition_return)
+
+        self.greengrass.create_function_definition_version = MagicMock(
+            return_value=function_definition_version_return)
+
         self.iot = MagicMock()
         self.iot.create_keys_and_certificate = MagicMock(
             return_value=state.get('Cores')[0]['keys'])
@@ -43,10 +53,20 @@ class BotoSessionFixture():
         self.iot.create_policy = MagicMock(
             return_value=state.get('Cores')[0]['policy'])
 
+        self._lambda = MagicMock()
+        self._lambda.create_function = MagicMock(return_value=state.get('Lambdas')[0])
+        self._lambda.create_alias = MagicMock(
+            return_value={
+                'FunctionVersion': state.get('Lambdas')[0]['Version'],
+                'AliasArn': state.get('Lambdas')[0]['FunctionArn'],
+            })
+
     def client(self, name):
         if name == 'greengrass':
             return self.greengrass
         elif name == 'iot':
             return self.iot
+        elif name == 'lambda':
+            return self._lambda
 
         return MagicMock()

--- a/tests/greengo_test.py
+++ b/tests/greengo_test.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import unittest2 as unittest
 from mock import patch
-from fixtures import BotoSessionFixture, clone_test_state  # XXX: better name
+from fixtures import BotoSessionFixture, clone_test_state
 
 from greengo import greengo
 from greengo.state import State

--- a/tests/lambdas_test.py
+++ b/tests/lambdas_test.py
@@ -79,3 +79,35 @@ class LambdasTest(unittest.TestCase):
         la._iam.create_role = MagicMock(side_effect=error)
         arn = la._default_lambda_role_arn()  # Doesn't blow up
         self.assertIsNotNone(arn)
+
+    def test_lambda_remove(self):
+        group = yaml.load(lambdas_yaml)
+        state = clone_test_state()
+        self.assertTrue(state.get('Lambdas'))
+        self.assertTrue(state.get('FunctionDefinition'))
+        self.assertTrue(state.get('LambdaRole'))
+
+        la = Lambdas(group, state)
+
+        with patch('os.remove'):
+            # import pdb; pdb.set_trace()
+            la._do_remove()
+
+        self.assertTrue(la._lambda.delete_function.called)
+        self.assertTrue(la._gg.delete_function_definition.called)
+        self.assertFalse(state.get('Lambdas'))
+        self.assertFalse(state.get('FunctionDefinition'))
+        self.assertFalse(state.get('LambdaRole'))
+
+    def test_lambda_remove__no_function_definitions(self):
+        group = yaml.load(lambdas_yaml)
+        state = clone_test_state()
+        self.assertTrue(state.get('Lambdas'))
+        state.remove('FunctionDefinition')
+
+        la = Lambdas(group, state)
+        with patch('os.remove'):
+            la._do_remove()
+
+        self.assertTrue(la._lambda.delete_function.called)
+        self.assertFalse(la._gg.delete_function_definition.called)

--- a/tests/lambdas_test.py
+++ b/tests/lambdas_test.py
@@ -1,7 +1,6 @@
 import unittest2 as unittest
 import yaml
 from mock import patch, MagicMock
-import logging
 from botocore.exceptions import ClientError
 
 from fixtures import BotoSessionFixture, clone_test_state
@@ -9,9 +8,9 @@ from greengo import greengo
 from greengo.lambdas import Lambdas
 from greengo.state import State
 
-logging.basicConfig(
-    format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
-    level=logging.DEBUG)
+# logging.basicConfig(
+#     format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
+#     level=logging.DEBUG)
 
 # Do not override the production state, work with testing state.
 greengo.STATE_FILE = '.gg_state_test.json'

--- a/tests/lambdas_test.py
+++ b/tests/lambdas_test.py
@@ -1,0 +1,81 @@
+import unittest2 as unittest
+import yaml
+from mock import patch, MagicMock
+import logging
+from botocore.exceptions import ClientError
+
+from fixtures import BotoSessionFixture, clone_test_state
+from greengo import greengo
+from greengo.lambdas import Lambdas
+from greengo.state import State
+
+logging.basicConfig(
+    format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
+    level=logging.DEBUG)
+
+# Do not override the production state, work with testing state.
+greengo.STATE_FILE = '.gg_state_test.json'
+
+lambdas_yaml = '''
+Group:
+    name: my_group
+Lambdas:
+  - name: GreengrassHelloWorld
+    runtime: Python2.7
+    handler: function.handler
+    package: lambdas/GreengrassHelloWorld
+    alias: dev
+    environment:
+      foo: bar
+    greengrassConfig:
+      MemorySize: 128000 # Kb, ask AWS why
+      Timeout: 10 # Sec
+      Pinned: True # Set True for long-lived functions
+      Environment:
+        AccessSysfs: False
+        ResourceAccessPolicies:
+          - ResourceId: 1_path_to_input
+            Permission: 'rw'
+        Variables:
+           name: value
+'''
+
+
+class LambdasTest(unittest.TestCase):
+    def setUp(self):
+        with patch.object(greengo.session, 'Session', BotoSessionFixture) as f:
+            self.boto_session = f
+            self.gg = greengo.Commands()
+
+    def tearDown(self):
+        pass
+
+    def test_lambda_create(self):
+        group = yaml.load(lambdas_yaml)
+        state = clone_test_state()
+        state.remove('Lambdas')
+        Lambdas(group, state)._do_create()
+
+    def test_default_lambda_role_arn__already_created(self):
+        group = yaml.load(lambdas_yaml)
+        state = clone_test_state()
+        arn = Lambdas(group, state)._default_lambda_role_arn()
+        self.assertEqual(arn, state.get('LambdaRole.Role.Arn'))
+
+    def test_default_lambda_role_arn__create(self):
+        group = yaml.load(lambdas_yaml)
+        arn = clone_test_state().get('LambdaRole.Role.Arn')
+        state = State(file=None)
+        arn = Lambdas(group, state)._default_lambda_role_arn()
+        self.assertEqual(arn, state.get('LambdaRole.Role.Arn'))
+
+    def test_default_lambda_role_arn__previously_defined(self):
+        group = yaml.load(lambdas_yaml)
+        la = Lambdas(group, State(file=None))
+        error = ClientError(
+            error_response={'Error': {'Code': 'EntityAlreadyExists'}},
+            operation_name='CreateRole')
+
+        la._iam.create_role = MagicMock(side_effect=error)
+        arn = la._default_lambda_role_arn()  # Doesn't blow up
+        self.assertIsNotNone(arn)

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -53,6 +53,13 @@ class StateTest(unittest.TestCase):
         self.state.remove()
         self.assertDictEqual({}, self.state.get())
 
+    def test_append(self):
+        # There's no `append` method but here is the way to append or overwise
+        # manipulate lists inside State.
+        self.state.update('list', [1, 2, 3])
+        self.state.get('list').append(4)
+        self.assertListEqual(self.state.get('list'), [1, 2, 3, 4])
+
 
 class StateTestWithFile(unittest.TestCase):
     def setUp(self):

--- a/tests/subscriptions_test.py
+++ b/tests/subscriptions_test.py
@@ -1,0 +1,87 @@
+import unittest2 as unittest
+import yaml
+from mock import patch
+
+from fixtures import BotoSessionFixture, clone_test_state
+from greengo import greengo
+from greengo.subscriptions import Subscriptions
+
+# Do not override the production state, work with testing state.
+greengo.STATE_FILE = '.gg_state_test.json'
+
+greengo_yaml = '''
+Group:
+    name: my_group
+Subscriptions:
+  - Source: Lambda::GreengrassHelloWorld
+    Subject: lambda2cloud
+    Target: cloud
+  - Source: cloud
+    Subject: cloud2lambda
+    Target: Lambda::GreengrassHelloWorld
+  - Source: cloud
+    Subject: cloud2connector
+    Target: Connector::ModbusProtocolAdapterConnector
+  - Source: GGShadowService
+    Subject: shadow2cloud
+    Target: cloud
+'''
+
+ministate = {
+    "Connectors": {
+        "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/connectors/0000",
+        "LatestVersionDetails": {
+            "Definition": {
+                "Connectors": [{
+                    "ConnectorArn": "arn:aws:greengrass:us-west-2::/connectors/XXXXX",
+                    "Id": "ModbusProtocolAdapterConnector"
+
+                }]
+            },
+        },
+        "Name": "Modbus-greengate_connectors"
+    },
+    "Lambdas": [
+        {
+            "FunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:GreengrassHelloWorld",
+            "FunctionName": "GreengrassHelloWorld",
+        }
+    ],
+}
+
+
+class SubscriptionsTest(unittest.TestCase):
+    '''
+    Subscription's `create` and `remove` are tested in greengo_test.
+    Here comes extra tests for elaborate private methods.
+    '''
+    def setUp(self):
+        with patch.object(greengo.session, 'Session', BotoSessionFixture):
+            self.gg = greengo.Commands()
+
+    def tearDown(self):
+        pass
+
+    def test_resolve_subscription_destionation(self):
+        group = yaml.load(greengo_yaml)
+        s = Subscriptions(group, clone_test_state())
+
+        self.assertEqual(
+            s._resolve_subscription_destination("Connector::ModbusProtocolAdapterConnector"),
+            s._state.get('Connectors.LatestVersionDetails.Definition.Connectors')[0]['ConnectorArn']
+        )
+
+        self.assertEqual(
+            s._resolve_subscription_destination("Lambda::GreengrassHelloWorld"),
+            s._state.get('FunctionDefinition.LatestVersionDetails.Definition.Functions')[0]['FunctionArn']
+        )
+
+        self.assertEqual(
+            s._resolve_subscription_destination("cloud"),
+            "cloud"
+        )
+
+        self.assertEqual(
+            s._resolve_subscription_destination("GGShadowService"),
+            "GGShadowService"
+        )

--- a/tests/test_state.json
+++ b/tests/test_state.json
@@ -60,6 +60,15 @@
       }
     }
   ],
+  "Deployment": {
+    "DeploymentArn": "arn:aws:greengrass:us-east-1:000000000000:/greengrass/groups/384ddf6c-f562-48bd-b106-45209ba0a89e/deployments/adf6011f-ee23-4df8-9709-55abde819d5b",
+    "DeploymentId": "adf6011f-ee23-4df8-9709-55abde819d5b",
+    "Status": {
+      "DeploymentStatus": "Success",
+      "DeploymentType": "NewDeployment",
+      "UpdatedAt": "2019-02-14T07:18:22.406Z"
+    }
+  },
   "FunctionDefinition": {
     "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d",
     "CreationTimestamp": "2018-04-04T09:21:44.721Z",

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,13 +1,12 @@
 import unittest
 import shutil
 import os
-import logging
 
 from greengo import utils
 
-logging.basicConfig(
-    format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
-    level=logging.DEBUG)
+# logging.basicConfig(
+#     format='%(asctime)s|%(name).10s|%(levelname).5s: %(message)s',
+#     level=logging.DEBUG)
 
 TEST_KEY_PATH = "tests/certs"
 


### PR DESCRIPTION
This brings support for Lambdas, the main thing :)

- [x] create lambdas
- [x] remove lambdas
- [x] deploy
- [x] CLI test:
    - [x] create/remove - all deployment
    - [x] create, remove/create/remove subscriptions
    - [x] create, remove/create/remove lambdas

Group deployed on GG, saw it working once.

Keeping for next time:
- update lambda functions 
-  support for lambdas already defined up in AWS, per #21 
- [ ] CLI tests
