### PR TITLE
Fix float in range()

### DIFF
--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -124,7 +124,7 @@ class GroupCommands(object):
         self.state['Deployment'] = rinse(deployment)
         _update_state(self.state)
 
-        for i in range(DEPLOY_TIMEOUT / 2):
+        for i in range(DEPLOY_TIMEOUT // 2):
             sleep(2)
             deployment_status = self._gg.get_deployment_status(
                 GroupId=self.state['Group']['Id'],


### PR DESCRIPTION
The floating point calculation `DEPLOY_TIMEOUT / 2` was used in a call to `range()` in the implementation of `deploy()`. When using Python 3.7.2, this caused greengo to crash when deploying:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'float' object cannot be interpreted as an integer
```