### PR TITLE
v2 feature catch up with ML Inference demo

### DIFF
--- a/greengo/entity.py
+++ b/greengo/entity.py
@@ -80,7 +80,8 @@ class Entity(object):
         raise NotImplementedError
 
     def _post_remove(self, update_group_version):
-        self._state.remove(self.type)
+        # While we can do self._state.remove(self.type) here,
+        # I concluded it's better to leave it to each entity to deal with it's state.
         if update_group_version:
             log.info("Updating group version with {} removed...".format(self.type))
             self.create_group_version(self._state)

--- a/greengo/entity.py
+++ b/greengo/entity.py
@@ -80,11 +80,11 @@ class Entity(object):
         raise NotImplementedError
 
     def _post_remove(self, update_group_version):
-        self._state.remove(self.type)
         if update_group_version:
             log.info("Updating group version with {} removed...".format(self.type))
             self.create_group_version(self._state)
 
+        self._state.remove(self.type)
         log.info("{} removed OK!".format(self.type.lower()))
 
     @classmethod

--- a/greengo/entity.py
+++ b/greengo/entity.py
@@ -80,8 +80,7 @@ class Entity(object):
         raise NotImplementedError
 
     def _post_remove(self, update_group_version):
-        # While we can do self._state.remove(self.type) here,
-        # I concluded it's better to leave it to each entity to deal with it's state.
+        self._state.remove(self.type)
         if update_group_version:
             log.info("Updating group version with {} removed...".format(self.type))
             self.create_group_version(self._state)
@@ -99,17 +98,17 @@ class Entity(object):
         kwargs = dict(
             GroupId=state.get('Group')['Id'],  # REQUIRED
             CoreDefinitionVersionArn=state.get(
-                'CoreDefinition', {}).get('LatestVersionArn', ""),
+                'CoreDefinition.LatestVersionArn', ""),
             FunctionDefinitionVersionArn=state.get(
-                'FunctionDefinition', {}).get('LatestVersionArn', ""),
+                'Lambdas.FunctionDefinition.LatestVersionArn', ""),
             SubscriptionDefinitionVersionArn=state.get(
-                'Subscriptions', {}).get('LatestVersionArn', ""),
+                'Subscriptions.LatestVersionArn', ""),
             LoggerDefinitionVersionArn=state.get(
-                'Loggers', {}).get('LatestVersionArn', ""),
+                'Loggers.LatestVersionArn', ""),
             ResourceDefinitionVersionArn=state.get(
-                'Resources', {}).get('LatestVersionArn', ""),
+                'Resources.LatestVersionArn', ""),
             ConnectorDefinitionVersionArn=state.get(
-                'Connectors', {}).get('LatestVersionArn', ""),
+                'Connectors.LatestVersionArn', ""),
             DeviceDefinitionVersionArn=""  # NOT IMPLEMENTED
         )
         args = dict((k, v) for k, v in kwargs.items() if v)

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -126,6 +126,9 @@ class Commands(object):
     def remove_subscriptions(self):
         Subscriptions(self.group, self.state).remove()
 
+    def update_lambda(self, lambda_name):
+        Lambdas(self.group, self.state).update_lambda(lambda_name)
+
     def deploy(self):
         if not self.state:
             log.info("There is nothing to deploy. Do create first.")

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -14,6 +14,7 @@ from .group import Group
 from .lambdas import Lambdas
 from .subscriptions import Subscriptions
 from .resources import Resources
+from .loggers import Loggers
 
 log = logging.getLogger(__name__)
 
@@ -68,13 +69,17 @@ class Commands(object):
 
         Group(self.group, self.state).create(update_group_version=False)
 
+        # Create other entities, as defined in a group.
+
         Lambdas(self.group, self.state).create(update_group_version=False)
 
         Subscriptions(self.group, self.state).create(update_group_version=False)
 
         Resources(self.group, self.state).create(update_group_version=False)
 
-        # Create other entities like this...
+        Loggers(self.group, self.state).create(update_group_version=False)
+
+        # Other entities go here...
 
         Group.create_group_version(self.state)
 
@@ -90,6 +95,10 @@ class Commands(object):
         Subscriptions(self.group, self.state).remove(update_group_version=False)
 
         Lambdas(self.group, self.state).remove(update_group_version=False)
+
+        Resources(self.group, self.state).remove(update_group_version=False)
+
+        Loggers(self.group, self.state).remove(update_group_version=False)
 
         # Remove other entities here, before removing Group.
 

--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -13,6 +13,7 @@ from .state import State
 from .group import Group
 from .lambdas import Lambdas
 from .subscriptions import Subscriptions
+from .resources import Resources
 
 log = logging.getLogger(__name__)
 
@@ -70,6 +71,8 @@ class Commands(object):
         Lambdas(self.group, self.state).create(update_group_version=False)
 
         Subscriptions(self.group, self.state).create(update_group_version=False)
+
+        Resources(self.group, self.state).create(update_group_version=False)
 
         # Create other entities like this...
 

--- a/greengo/group.py
+++ b/greengo/group.py
@@ -171,7 +171,7 @@ class Group(Entity):
 
         config = {
             "coreThing": {
-                "caPath": "root-CA.crt",
+                "caPath": "root.ca.pem",
                 "certPath": core_thing['thingName'] + ".pem",
                 "keyPath": core_thing['thingName'] + ".key",
                 "thingArn": core_thing['thingArn'],

--- a/greengo/loggers.py
+++ b/greengo/loggers.py
@@ -1,0 +1,43 @@
+import logging
+
+from .utils import rinse
+from .entity import Entity
+
+log = logging.getLogger(__name__)
+
+
+class Loggers(Entity):
+
+    def __init__(self, group, state):
+        super(Loggers, self).__init__(group, state)
+        self.type = 'Loggers'
+        self.name = group['Group']['name'] + '_loggers'
+
+        self._requirements = ['Group']
+        self._gg = Entity._session.client("greengrass")
+
+    def _do_create(self):
+        log.info("Creating loggers definition: '{0}'".format(self.name))
+
+        l_def = rinse(self._gg.create_logger_definition(
+            Name=self.name,
+            InitialVersion={'Loggers': self._group['Loggers']}
+        ))
+
+        self._state.update('Loggers', l_def)
+
+        l_def_ver = rinse(self._gg.get_logger_definition_version(
+            LoggerDefinitionId=self._state.get('Loggers.Id'),
+            LoggerDefinitionVersionId=self._state.get('Loggers.LatestVersion')
+        ))
+
+        self._state.update('Loggers.LatestVersionDetails', l_def_ver)
+
+    def _do_remove(self):
+        log.debug("Deleting logger definition '{0}' Id='{1}".format(
+            self.name, self._state.get('Loggers.Id')))
+
+        self._gg.delete_logger_definition(
+            LoggerDefinitionId=self._state.get('Loggers.Id'))
+
+        self._state.remove(self.type)

--- a/greengo/resources.py
+++ b/greengo/resources.py
@@ -40,7 +40,7 @@ class Resources(Entity):
             ResourceDefinitionVersionId=self._state.get('Resources.LatestVersion')
         ))
 
-        self._state.update('Subscriptions.LatestVersionDetails', res_def_ver)
+        self._state.update('Resources.LatestVersionDetails', res_def_ver)
 
     def _do_remove(self):
         log.debug("Deleting resources definition '{0}' Id='{1}".format(

--- a/greengo/resources.py
+++ b/greengo/resources.py
@@ -48,4 +48,4 @@ class Resources(Entity):
         self._gg.delete_resource_definition(
             ResourceDefinitionId=self._state.get('Resources.Id'))
 
-        self._state.remove('Resources')
+        self._state.remove(self.type)

--- a/greengo/resources.py
+++ b/greengo/resources.py
@@ -1,0 +1,51 @@
+import logging
+
+from .utils import pretty, rinse
+from .entity import Entity
+
+log = logging.getLogger(__name__)
+
+
+class Resources(Entity):
+
+    def __init__(self, group, state):
+        super(Resources, self).__init__(group, state)
+        self.type = 'Resources'
+        self.name = group['Group']['name'] + '_resources'
+
+        self._requirements = ['Group']
+        self._gg = Entity._session.client("greengrass")
+
+    def _do_create(self):
+        log.debug("Preparing resources list...")
+        res = []
+        for r in self._group['Resources']:
+            # Convert from a simplified form to AWS API input
+            resource = dict(Name=r.pop('Name'), Id=r.pop('Id'))
+            resource['ResourceDataContainer'] = r
+            res.append(resource)
+
+        log.debug("Resources list is ready:\n{0}".format(pretty(res)))
+
+        log.info("Creating resource definition: '{0}'".format(self.name))
+        res_def = rinse(self._gg.create_resource_definition(
+            Name=self.name,
+            InitialVersion={'Resources': res}
+        ))
+
+        self._state.update('Resources', res_def)
+
+        res_def_ver = rinse(self._gg.get_resource_definition_version(
+            ResourceDefinitionId=self._state.get('Resources.Id'),
+            ResourceDefinitionVersionId=self._state.get('Resources.LatestVersion')
+        ))
+
+        self._state.update('Subscriptions.LatestVersionDetails', res_def_ver)
+
+    def _do_remove(self):
+        log.debug("Deleting resources definition '{0}' Id='{1}".format(
+            self.name, self._state.get('Resources.Id')))
+        self._gg.delete_resource_definition(
+            ResourceDefinitionId=self._state.get('Resources.Id'))
+
+        self._state.remove('Resources')

--- a/greengo/state.py
+++ b/greengo/state.py
@@ -84,7 +84,14 @@ class State(object):
     def remove(self, key=None):
         if key:
             try:
-                self._state.pop(key)
+                (path, dot, k) = key.rpartition('.')
+                if path:
+                    branch = self.get(path)
+                    if not branch or type(branch) is not dict:
+                        raise KeyError
+                    branch.pop(k)
+                else:
+                    self._state.pop(key)
                 self.save()
             except KeyError:
                 log.warning("Can not remove key '{}' from State - missing".format(key))

--- a/greengo/subscriptions.py
+++ b/greengo/subscriptions.py
@@ -50,8 +50,6 @@ class Subscriptions(Entity):
         self._gg.delete_subscription_definition(
             SubscriptionDefinitionId=self._state.get('Subscriptions.Id'))
 
-        self._state.remove(self.type)
-
     def _resolve_subscription_destination(self, d):
         p = [x.strip() for x in d.split('::')]
         if p[0] == 'cloud':

--- a/greengo/subscriptions.py
+++ b/greengo/subscriptions.py
@@ -50,6 +50,8 @@ class Subscriptions(Entity):
         self._gg.delete_subscription_definition(
             SubscriptionDefinitionId=self._state.get('Subscriptions.Id'))
 
+        self._state.remove(self.type)
+
     def _resolve_subscription_destination(self, d):
         p = [x.strip() for x in d.split('::')]
         if p[0] == 'cloud':

--- a/greengo/subscriptions.py
+++ b/greengo/subscriptions.py
@@ -70,7 +70,7 @@ class Subscriptions(Entity):
                 "'Lambda::', 'Device::', 'Connector::', 'GGShadowService', or 'cloud'.".format(d))
 
     def _lookup_lambda_qualified_arn(self, name):
-        for l in self._state.get('FunctionDefinition.LatestVersionDetails.Definition.Functions', []):
+        for l in self._state.get('Lambdas.FunctionDefinition.LatestVersionDetails.Definition.Functions', []):
             if l['Id'] == name:
                 return l['FunctionArn']
         log.error("Lambda '{0}' not found".format(name))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -24,13 +24,21 @@ class BotoSessionFixture():
         self.greengrass.create_core_definition = MagicMock(
             return_value=state.get('CoreDefinition'))
 
-        subscriptions_return = state.get('Subscriptions').copy()
-        subscription_definition_return = subscriptions_return.pop('LatestVersionDetails')
+        subscription_def_return = state.get('Subscriptions').copy()
+        subscription_def_version_return = subscription_def_return.pop('LatestVersionDetails')
 
         self.greengrass.create_subscription_definition = MagicMock(
-            return_value=subscriptions_return)
+            return_value=subscription_def_return)
         self.greengrass.get_subscription_definition_version = MagicMock(
-            return_value=subscription_definition_return)
+            return_value=subscription_def_version_return)
+
+        resource_def_return = state.get('Resources').copy()
+        resource_def_version_return = resource_def_return.pop('LatestVersionDetails')
+
+        self.greengrass.create_resource_definition = MagicMock(
+            return_value=resource_def_return)
+        self.greengrass.get_resource_definition_version = MagicMock(
+            return_value=resource_def_version_return)
 
         function_definition_return = state.get('FunctionDefinition').copy()
         function_definition_version_return = function_definition_return.pop('LatestVersionDetails')

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -50,6 +50,9 @@ class BotoSessionFixture():
         self.greengrass.get_function_definition_version = MagicMock(
             return_value=function_definition_version_return)
 
+        self.greengrass.create_logger_definition = MagicMock(
+            return_value=state.get('Loggers'))
+
         self.iot = MagicMock()
         self.iot.create_keys_and_certificate = MagicMock(
             return_value=state.get('Cores')[0]['keys'])

--- a/tests/greengo_test.py
+++ b/tests/greengo_test.py
@@ -44,6 +44,7 @@ class CommandTest(unittest.TestCase):
         self.assertIsNotNone(self.gg.state.get('CoreDefinition'))
         self.assertIsNotNone(self.gg.state.get('Subscriptions'))
         self.assertIsNotNone(self.gg.state.get('Resources'))
+        self.assertIsNotNone(self.gg.state.get('Loggers'))
         self.assertIsNotNone(self.gg.state.get('Group.Version'))
 
         # Check that cert and config files have been created
@@ -81,6 +82,11 @@ class CommandTest(unittest.TestCase):
         self.assertTrue(gg.delete_function_definition.called)
         # Subscriptions
         self.assertTrue(gg.delete_subscription_definition.called)
+        # Resources
+        self.assertTrue(gg.delete_resource_definition.called)
+        # Loggers
+        self.assertTrue(gg.delete_logger_definition.called)
+
         # Core
         self.assertTrue(gg.delete_core_definition.called)
         self.assertTrue(iot.delete_thing)

--- a/tests/greengo_test.py
+++ b/tests/greengo_test.py
@@ -43,6 +43,7 @@ class CommandTest(unittest.TestCase):
         self.assertIsNotNone(self.gg.state.get('Cores'))
         self.assertIsNotNone(self.gg.state.get('CoreDefinition'))
         self.assertIsNotNone(self.gg.state.get('Subscriptions'))
+        self.assertIsNotNone(self.gg.state.get('Resources'))
         self.assertIsNotNone(self.gg.state.get('Group.Version'))
 
         # Check that cert and config files have been created
@@ -172,8 +173,8 @@ class CommandTest(unittest.TestCase):
 
         self.gg.remove_subscriptions()
         self.assertIsNone(self.gg.state.get('Subscriptions'))
-        print(Entity._session.greengrass.delete_subscription_definition.assert_called_once_with(
-            SubscriptionDefinitionId=expected_id))
+        Entity._session.greengrass.delete_subscription_definition.assert_called_once_with(
+            SubscriptionDefinitionId=expected_id)
 
 
 class EntityTest(unittest.TestCase):

--- a/tests/lambdas_test.py
+++ b/tests/lambdas_test.py
@@ -53,21 +53,38 @@ class LambdasTest(unittest.TestCase):
     def test_lambda_create(self):
         group = self.group
         state = clone_test_state()
+        functions = state.get('Lambdas.Functions')
+        function_def = state.get('Lambdas.FunctionDefinition')
+        lambda_role = state.get('Lambdas.LambdaRole')
+
         state.remove('Lambdas')
+
         Lambdas(group, state)._do_create()
+
+        self.assertEqual(
+            state.get('Lambdas.Functions')[0]['FunctionArn'],
+            functions[0]['FunctionArn'])
+        self.assertDictEqual(
+            state.get('Lambdas.FunctionDefinition'),
+            function_def
+        )
+        self.assertDictEqual(
+            state.get('Lambdas.LambdaRole'),
+            lambda_role
+        )
 
     def test_default_lambda_role_arn__already_created(self):
         group = self.group
         state = clone_test_state()
         arn = Lambdas(group, state)._default_lambda_role_arn()
-        self.assertEqual(arn, state.get('LambdaRole.Role.Arn'))
+        self.assertEqual(arn, state.get('Lambdas.LambdaRole.Role.Arn'))
 
     def test_default_lambda_role_arn__create(self):
         group = self.group
-        arn = clone_test_state().get('LambdaRole.Role.Arn')
+        arn = clone_test_state().get('Lambdas.LambdaRole.Role.Arn')
         state = State(file=None)
         arn = Lambdas(group, state)._default_lambda_role_arn()
-        self.assertEqual(arn, state.get('LambdaRole.Role.Arn'))
+        self.assertEqual(arn, state.get('Lambdas.LambdaRole.Role.Arn'))
 
     def test_default_lambda_role_arn__previously_defined(self):
         group = self.group
@@ -83,9 +100,10 @@ class LambdasTest(unittest.TestCase):
     def test_lambda_remove(self):
         group = self.group
         state = clone_test_state()
-        self.assertTrue(state.get('Lambdas'))
-        self.assertTrue(state.get('FunctionDefinition'))
-        self.assertTrue(state.get('LambdaRole'))
+
+        self.assertTrue(state.get('Lambdas.Functions'))
+        self.assertTrue(state.get('Lambdas.FunctionDefinition'))
+        self.assertTrue(state.get('Lambdas.LambdaRole'))
 
         la = Lambdas(group, state)
 
@@ -95,15 +113,15 @@ class LambdasTest(unittest.TestCase):
 
         self.assertTrue(la._lambda.delete_function.called)
         self.assertTrue(la._gg.delete_function_definition.called)
-        self.assertFalse(state.get('Lambdas'))
-        self.assertFalse(state.get('FunctionDefinition'))
-        self.assertFalse(state.get('LambdaRole'))
+        self.assertFalse(state.get('Lambdas.Functions'))
+        self.assertFalse(state.get('Lambdas.FunctionDefinition'))
+        self.assertFalse(state.get('Lambdas.LambdaRole'))
 
     def test_lambda_remove__no_function_definitions(self):
         group = self.group
         state = clone_test_state()
-        self.assertTrue(state.get('Lambdas'))
-        state.remove('FunctionDefinition')
+        self.assertTrue(state.get('Lambdas.FunctionDefinition'))
+        state.remove('Lambdas.FunctionDefinition')
 
         la = Lambdas(group, state)
         with patch('os.remove'):

--- a/tests/loggers_test.py
+++ b/tests/loggers_test.py
@@ -1,0 +1,50 @@
+import unittest2 as unittest
+import yaml
+from mock import patch
+from .fixtures import BotoSessionFixture, clone_test_state
+from greengo import greengo
+from greengo.loggers import Loggers
+
+# Do not override the production state, work with testing state.
+greengo.STATE_FILE = '.gg_state_test.json'
+
+# For Loggers parameter definitions,
+# see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/greengrass.html#Greengrass.Client.create_logger_definition
+
+greengo_yaml = '''
+Group:
+    name: my_group
+Loggers:
+  - Component: Lambda  # 'GreengrassSystem'|'Lambda'
+    Id: logger_1       # Arbitrary string
+    Level: DEBUG       # 'DEBUG'|'INFO'|'WARN'|'ERROR'|'FATAL'
+    Space: 1024        # The amount of file space, in KB, to use if the local file system
+    Type: FileSystem   # 'FileSystem'|'AWSCloudWatch'
+'''
+
+
+class LoggersTest(unittest.TestCase):
+    def setUp(self):
+        self.group = yaml.safe_load(greengo_yaml)
+        with patch.object(greengo.session, 'Session', BotoSessionFixture):
+            self.gg = greengo.Commands()
+
+    def tearDown(self):
+        pass
+
+    def test_loggers_create(self):
+        state = clone_test_state()
+        state.remove('Loggers')
+        l = Loggers(self.group, state)
+        l._do_create()
+        self.assertTrue(l._gg.create_logger_definition.called)
+        self.assertTrue(l._gg.get_logger_definition_version.called)
+        self.assertTrue(state.get('Loggers'))
+
+    def test_loggers_remove(self):
+        state = clone_test_state()
+        l = Loggers(self.group, state)
+        l._do_remove()
+        self.assertTrue(l._gg.delete_logger_definition.called)
+
+        self.assertFalse(state.get('Loggers'))

--- a/tests/resources_test.py
+++ b/tests/resources_test.py
@@ -1,0 +1,49 @@
+import unittest2 as unittest
+import yaml
+from mock import patch
+
+from .fixtures import BotoSessionFixture, clone_test_state
+from greengo import greengo
+from greengo.resources import Resources
+
+# Do not override the production state, work with testing state.
+greengo.STATE_FILE = '.gg_state_test.json'
+
+greengo_yaml = '''
+Group:
+    name: my_group
+Resources:
+  - Name: path_to_input
+    Id: resource_1_path_to_input
+    LocalVolumeResourceData:
+      SourcePath: /images
+      DestinationPath: /input
+      GroupOwnerSetting:
+        AutoAddGroupOwner: True
+'''
+
+
+class ResourcesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.group = yaml.safe_load(greengo_yaml)
+        with patch.object(greengo.session, 'Session', BotoSessionFixture):
+            self.gg = greengo.Commands()
+
+    def tearDown(self):
+        pass
+
+    def test_resources_create(self):
+        state = clone_test_state()
+        state.remove('Resources')
+        r = Resources(self.group, state)
+        r._do_create()
+        self.assertTrue(r._gg.create_resource_definition.called)
+        self.assertTrue(r._gg.get_resource_definition_version.called)
+        self.assertTrue(state.get('Resources'))
+
+    def test_resources_remove(self):
+        state = clone_test_state()
+        r = Resources(self.group, state)
+        r._do_remove()
+        self.assertFalse(state.get('Resources'))

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -8,7 +8,7 @@ from greengo.state import State
 class StateTest(unittest.TestCase):
     def setUp(self):
         self.state = State(file=None)
-        self.body = {'a': {'b': 'c'}, 'x': {'y': {'z': 1}}}
+        self.body = {'a': {'b': 'c', 'd': 'e'}, 'x': {'y': {'z': 1}}}
         self.state._state = self.body
 
     def tearDown(self):
@@ -52,6 +52,19 @@ class StateTest(unittest.TestCase):
 
         self.state.remove()
         self.assertDictEqual({}, self.state.get())
+
+    def test_remove__nested(self):
+        self.assertEqual(self.body['a']['b'], self.state.get('a.b'))
+        self.state.remove('a.b')
+        self.assertEqual(self.state.get('a.b'), None)
+        self.assertEqual(self.state.get('a.d'), 'e')
+
+        self.state.remove('x.y.z')
+        self.assertEqual(self.state.get('x.y.z'), None)
+
+    def test_remove__nested_missing(self):
+        self.state.remove('key.doesnt.exist')
+        self.state.remove('a.b.key_doesnt_exist')
 
     def test_append(self):
         # There's no `append` method but here is the way to append or overwise

--- a/tests/subscriptions_test.py
+++ b/tests/subscriptions_test.py
@@ -27,28 +27,6 @@ Subscriptions:
     Target: cloud
 '''
 
-ministate = {
-    "Connectors": {
-        "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/connectors/0000",
-        "LatestVersionDetails": {
-            "Definition": {
-                "Connectors": [{
-                    "ConnectorArn": "arn:aws:greengrass:us-west-2::/connectors/XXXXX",
-                    "Id": "ModbusProtocolAdapterConnector"
-
-                }]
-            },
-        },
-        "Name": "Modbus-greengate_connectors"
-    },
-    "Lambdas": [
-        {
-            "FunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:GreengrassHelloWorld",
-            "FunctionName": "GreengrassHelloWorld",
-        }
-    ],
-}
-
 
 class SubscriptionsTest(unittest.TestCase):
     '''
@@ -70,10 +48,10 @@ class SubscriptionsTest(unittest.TestCase):
             s._resolve_subscription_destination("Connector::ModbusProtocolAdapterConnector"),
             s._state.get('Connectors.LatestVersionDetails.Definition.Connectors')[0]['ConnectorArn']
         )
-
         self.assertEqual(
             s._resolve_subscription_destination("Lambda::GreengrassHelloWorld"),
-            s._state.get('FunctionDefinition.LatestVersionDetails.Definition.Functions')[0]['FunctionArn']
+            s._state.get(
+                'Lambdas.FunctionDefinition.LatestVersionDetails.Definition.Functions')[0]['FunctionArn']
         )
 
         self.assertEqual(

--- a/tests/test_state.json
+++ b/tests/test_state.json
@@ -69,40 +69,7 @@
       "UpdatedAt": "2019-02-14T07:18:22.406Z"
     }
   },
-  "FunctionDefinition": {
-    "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d",
-    "CreationTimestamp": "2018-04-04T09:21:44.721Z",
-    "Id": "3164383a-7c4c-4533-8fad-a6a451052a4d",
-    "LastUpdatedTimestamp": "2018-04-04T09:21:44.721Z",
-    "LatestVersion": "731186cb-d46e-4ea8-b97f-edfd59600369",
-    "LatestVersionArn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d/versions/731186cb-d46e-4ea8-b97f-edfd59600369",
-    "LatestVersionDetails": {
-      "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d/versions/731186cb-d46e-4ea8-b97f-edfd59600369",
-      "CreationTimestamp": "2018-04-04T09:21:44.721Z",
-      "Definition": {
-        "Functions": [
-          {
-            "FunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:GreengrassHelloWorld:dev",
-            "FunctionConfiguration": {
-              "Environment": {
-                "AccessSysfs": false,
-                "Variables": {
-                  "name": "value"
-                }
-              },
-              "MemorySize": 128000,
-              "Pinned": true,
-              "Timeout": 10
-            },
-            "Id": "GreengrassHelloWorld"
-          }
-        ]
-      },
-      "Id": "3164383a-7c4c-4533-8fad-a6a451052a4d",
-      "Version": "731186cb-d46e-4ea8-b97f-edfd59600369"
-    },
-    "Name": "GreengoGroup_func_def_1"
-  },
+
   "Group": {
     "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/groups/384ddf6c-f562-48bd-b106-45209ba0a89e",
     "CreationTimestamp": "2018-04-04T09:21:25.978Z",
@@ -116,54 +83,89 @@
       "Version": "db511c52-fcc9-495c-8dc3-c703736939db"
     }
   },
-  "Group.Version": "<MagicMock name='mock.create_group_version()' id='4518902096'>",
-  "LambdaRole": {
-    "Role": {
-      "Arn": "arn:aws:iam::000000000000:role/GreengoGroup_Lambda_Role",
-      "AssumeRolePolicyDocument": {
-        "Statement": [
-          {
-            "Action": "sts:AssumeRole",
-            "Effect": "Allow",
-            "Principal": {
-              "Service": "lambda.amazonaws.com"
+  "Lambdas": {
+    "FunctionDefinition": {
+      "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d",
+      "CreationTimestamp": "2018-04-04T09:21:44.721Z",
+      "Id": "3164383a-7c4c-4533-8fad-a6a451052a4d",
+      "LastUpdatedTimestamp": "2018-04-04T09:21:44.721Z",
+      "LatestVersion": "731186cb-d46e-4ea8-b97f-edfd59600369",
+      "LatestVersionArn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d/versions/731186cb-d46e-4ea8-b97f-edfd59600369",
+      "LatestVersionDetails": {
+        "Arn": "arn:aws:greengrass:us-west-2:000000000000:/greengrass/definition/functions/3164383a-7c4c-4533-8fad-a6a451052a4d/versions/731186cb-d46e-4ea8-b97f-edfd59600369",
+        "CreationTimestamp": "2018-04-04T09:21:44.721Z",
+        "Definition": {
+          "Functions": [
+            {
+              "FunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:GreengrassHelloWorld:dev",
+              "FunctionConfiguration": {
+                "Environment": {
+                  "AccessSysfs": false,
+                  "Variables": {
+                    "name": "value"
+                  }
+                },
+                "MemorySize": 128000,
+                "Pinned": true,
+                "Timeout": 10
+              },
+              "Id": "GreengrassHelloWorld"
             }
-          }
-        ],
-        "Version": "2012-10-17"
+          ]
+        },
+        "Id": "3164383a-7c4c-4533-8fad-a6a451052a4d",
+        "Version": "731186cb-d46e-4ea8-b97f-edfd59600369"
       },
-      "CreateDate": "2018-04-04 09:21:29.979000+00:00",
-      "Path": "/",
-      "RoleId": "AROAJXSCI44V4FPDVM7UK",
-      "RoleName": "GreengoGroup_Lambda_Role"
+      "Name": "GreengoGroup_func_def_1"
+    },
+    "Functions": [
+      {
+        "CodeSha256": "zOSLlGYEOXjWfJ9iNFQTu7e7dcfqOOWwI3vkcxbMwoU=",
+        "CodeSize": 33260,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "foo": "bar"
+          }
+        },
+        "FunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:GreengrassHelloWorld",
+        "FunctionName": "GreengrassHelloWorld",
+        "Handler": "function.handler",
+        "LastModified": "2018-04-04T09:21:43.430+0000",
+        "MemorySize": 128,
+        "RevisionId": "82127cda-ee1c-4c90-80eb-3ae0e97e0115",
+        "Role": "arn:aws:iam::000000000000:role/GreengoGroup_Lambda_Role",
+        "Runtime": "python2.7",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "21",
+        "ZipPath": "/path/to/greengo/.gg/GreengrassHelloWorld.zip"
+      }
+    ],
+    "LambdaRole": {
+      "Role": {
+        "Arn": "arn:aws:iam::000000000000:role/GreengoGroup_Lambda_Role",
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "CreateDate": "2018-04-04 09:21:29.979000+00:00",
+        "Path": "/",
+        "RoleId": "AROAJXSCI44V4FPDVM7UK",
+        "RoleName": "GreengoGroup_Lambda_Role"
+      }
     }
   },
-  "Lambdas": [
-    {
-      "CodeSha256": "zOSLlGYEOXjWfJ9iNFQTu7e7dcfqOOWwI3vkcxbMwoU=",
-      "CodeSize": 33260,
-      "Description": "",
-      "Environment": {
-        "Variables": {
-          "foo": "bar"
-        }
-      },
-      "FunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:GreengrassHelloWorld",
-      "FunctionName": "GreengrassHelloWorld",
-      "Handler": "function.handler",
-      "LastModified": "2018-04-04T09:21:43.430+0000",
-      "MemorySize": 128,
-      "RevisionId": "82127cda-ee1c-4c90-80eb-3ae0e97e0115",
-      "Role": "arn:aws:iam::000000000000:role/GreengoGroup_Lambda_Role",
-      "Runtime": "python2.7",
-      "Timeout": 3,
-      "TracingConfig": {
-        "Mode": "PassThrough"
-      },
-      "Version": "21",
-      "ZipPath": "/path/to/greengo/.gg/GreengrassHelloWorld.zip"
-    }
-  ],
   "Loggers": {
     "Arn": "arn:aws:greengrass:us-east-1:000000000000:/greengrass/definition/loggers/d89956dd-18c0-4833-919f-aafa15e171cc",
     "CreationTimestamp": "2018-10-09T21:04:16.840Z",


### PR DESCRIPTION
Do enough of `greengo` to run ML-inference demo: https://github.com/dzimine/aws-greengrass-ml-inference

- [x] Implement `Resources`
- [x] Implement `Loggers`
- [x] Lambda updates
... and whatever else I'll find missing. 