### PR TITLE
Add check for Logger check for Type AWSCW and Space

### DIFF
--- a/greengo/greengo.py
+++ b/greengo/greengo.py
@@ -545,6 +545,12 @@ class GroupCommands(object):
 
         loggers = self.group['Loggers']
         name = self.name + '_loggers'
+
+        for logger in loggers: 
+            if 'Space' in logger and logger['Type'] == 'AWSCloudWatch':
+                log.error("Logs of type AWSCloudWatch cannot have 'Space' key")
+                return
+        
         log.info("Creating loggers definition: '{0}'".format(name))
 
         res_def = self._gg.create_logger_definition(


### PR DESCRIPTION
The combination of Space and Type=AWSCloudWatch will cause an exception. This will provide the user with a more verbose error 